### PR TITLE
Modify round display

### DIFF
--- a/src/controller/instructor/rounds.py
+++ b/src/controller/instructor/rounds.py
@@ -4,7 +4,7 @@ rounds.py
 Implements the APIs for Instructor control of adding discussion rounds.
 
 - Author(s): Rohit Kapoor, Swaroop Joshi, Tyler Rasor, Dustin Stanley
-- Last Modified: May 30, 2016
+- Last Modified: Sep 2, 2016
 
 --------------------
 
@@ -19,6 +19,7 @@ from google.appengine.api import users
 
 from src import model, utils
 
+
 def since_epoch(date):
     epoch = datetime.datetime.utcfromtimestamp(0)
     return (date - epoch).total_seconds() * 100.0
@@ -26,7 +27,7 @@ def since_epoch(date):
 
 """
 Returns the input DateTime (assumed to be in UTC) as a DateTime
-object convered over to the local timezone.
+object converted over to the local timezone.
 """
 
 
@@ -40,6 +41,176 @@ jinja2.filters.FILTERS['str_to_date'] = utils.str_to_datetime
 jinja2.filters.FILTERS['since_epoch'] = since_epoch
 jinja2.filters.FILTERS['local_time'] = local_time
 jinja2.filters.FILTERS['tzname'] = utils.tzname
+
+
+def get_new_times(start, num, duration, delay, start_buffer):
+    # First, we need to get the start time into something we can work with
+    # Grab the current time
+    start += datetime.timedelta(hours=start_buffer)
+
+    # Ok, now we need to create our new start and end times list
+    start_times = list()
+    end_times = list()
+    # And loop the correct number of times
+    for i in range(num):
+        # Create start and end times with the given duration and delay
+        start_time = start + datetime.timedelta(hours=i * (duration + delay))
+        end_time = start + datetime.timedelta(hours=(i + 1) * (duration + delay))
+        # And add to our arrays
+        start_times.append(start_time)
+        end_times.append(end_time)
+    # end
+    return start_times, end_times
+
+
+# end get_new_times
+
+def copy_summary(section, rounds, num_of_rounds):
+    summary = None
+    # First, check if there's even a summary round to copy
+    if rounds[-1].description == 'summary':
+        # If so, create a new summary round with those properties
+        # But change it to be the last round after adding num_of_rounds
+        summary_round_num = rounds[-1].number + num_of_rounds
+        summary = model.Round(parent=section.key, id=summary_round_num)
+        # Now copy over all the pertinent summary information
+        summary.starttime = rounds[-1].starttime
+        summary.deadline = rounds[-1].deadline
+        summary.number = summary_round_num
+        summary.is_quiz = True
+        summary.quiz = rounds[-1].quiz
+        summary.description = rounds[-1].description
+        summary.is_anonymous = rounds[-1].is_anonymous
+        # Now remove the summary from the current rounds
+        rounds[-1].put().delete()
+    # end
+    return summary
+
+
+# end copy_summary
+
+def update_section_rounds(num, section):
+    # Update the section rounds attribute if necessary
+    if num != section.rounds:
+        section.rounds = num
+        section.put()
+
+
+# end update_section_rounds
+
+
+def get_duration(start, end):
+    # First, check what type start and end were sent as
+    if type(start) != datetime.datetime:
+        start = utils.str_to_datetime(start)
+
+    if type(end) != datetime.datetime:
+        end = utils.str_to_datetime(end)
+
+    # Simply return the end time minus the start time
+    return end - start
+
+
+# end get_duration
+
+def add_lead_in(round_obj, rounds):
+    # We'll simply use unix epoch as the start time for initial questions
+    round_obj.starttime = datetime.datetime(1970, 1, 1)
+    # Now we need to check if there are more rounds
+    if rounds and len(rounds) > 1:
+        # Discussion directly after the initial will always be index 1
+        # If new initial deadline conflicts, shift rounds
+        if round_obj.deadline >= rounds[1].starttime:
+            # Now we need to shift all of the rounds, so loop over them
+            for i in range(1, len(rounds)):
+                # And grab the duration of the round
+                duration = get_duration(rounds[i].starttime, rounds[i].deadline)
+                # And grab the deadline of the previous round
+                new_start = rounds[i - 1].deadline
+                # Add the 24 hour padding for the first round
+                if i == 1:
+                    new_start = round_obj.deadline + datetime.timedelta(hours=24)
+
+                # And set our new start and end times and save
+                rounds[i].starttime = new_start
+                rounds[i].deadline = (new_start + duration)
+                rounds[i].put()
+
+
+# end add_lead_in
+
+def create_new_rounds(section, rounds, num_of_rounds, duration, buffer_bw_rounds):
+    # Now grab the current last round number
+    current_last_round = rounds[-1].number
+    # We need the end time of the last round currently in this section
+    last_time = rounds[-1].deadline
+    # And grab the start buffer from the previous round
+    start_buffer = rounds[-1].buffer_time
+    # Now we need to compute new start and end times for the new rounds
+    start_times, end_times = get_new_times(last_time, num_of_rounds, duration, buffer_bw_rounds, start_buffer)
+    # Let's keep a list of the newly added rounds
+    new_rounds = list()
+    # Now let's just loop over the number of rounds
+    for i in range(num_of_rounds):
+        # And increment the current round for this iteration
+        current_last_round += 1
+        # Create a new rounds object
+        new_round = model.Round(parent=section.key, id=current_last_round)
+        # Set the starttime and deadline
+        new_round.starttime = start_times[i]
+        new_round.deadline = end_times[i]
+        # And the round number
+        new_round.number = current_last_round
+        # And save our object
+        new_round.put()
+        # And add it to our list
+        new_rounds.append(new_round)
+    # end
+    return new_rounds
+
+
+# end create_new_rounds
+
+def shift_rounds(rounds, round_id):
+    # Now look for the round with the input id
+    for i in range(len(rounds)):
+        # Look for the correct round
+        if rounds[i].number == round_id:
+            # Now loop over the rest of the rounds (except the very last)
+            for j in range(i, len(rounds) - 1):
+                # We're just dealing with normal discussions
+                # and we can just shift the values directly
+                rounds[j].description = rounds[j + 1].description
+                # No need to move anything quiz related since it isn't
+                # a initial or summary question
+                # Lastly, we need to compute the duration to move over
+                duration = get_duration(rounds[j + 1].starttime, rounds[j + 1].deadline)
+                # Keep the old start time of rounds[j] and calculate
+                # the new end time
+                rounds[j].deadline = rounds[j].starttime + duration
+                # And store it to the database
+                rounds[j].put()
+            # end
+            break
+
+
+# end shift_rounds
+
+
+def update_summary(summary, rounds):
+    # And check if a summary round was saved
+    if summary:
+        # We need to calculate the old duration of the summary round
+        duration = get_duration(summary.starttime, summary.deadline)
+        # Set the summary start time to be the end of the last new round
+        summary.starttime = rounds[-1].deadline
+        summary.deadline = rounds[-1].deadline + duration
+        # And save it to the database and add to our list
+        summary.put()
+        rounds.append(summary)
+
+
+# end update_summary
 
 
 class Rounds(webapp2.RequestHandler):
@@ -223,7 +394,7 @@ class Rounds(webapp2.RequestHandler):
         rounds = model.Round.query(ancestor=section.key).fetch()
         # And switch on the type to create our start time
         if round_obj.description == 'initial':
-            self.add_lead_in(round_obj, rounds)
+            add_lead_in(round_obj, rounds)
         else:
             # If not a lead-in question, we know it's a summary
             # And check that we're not trying to add a summary as the first
@@ -259,7 +430,7 @@ class Rounds(webapp2.RequestHandler):
         # And grab all the rounds one last time
         rounds = model.Round.query(ancestor=section.key).fetch()
         # And update the section rounds attribute if necessary
-        self.update_section_rounds(rounds[-1].number, section)
+        update_section_rounds(rounds[-1].number, section)
         # And send our success message
         # utils.log('Success, round added.', type='Success!', handler=self)
         utils.log(
@@ -305,34 +476,6 @@ class Rounds(webapp2.RequestHandler):
 
     # end build_round_obj
 
-    def add_lead_in(self, round_obj, rounds):
-        # We'll simply use unix epoch as the start time for initial questions
-        round_obj.starttime = datetime.datetime(1970, 1, 1)
-        # Now we need to check if there are more rounds
-        if rounds and len(rounds) > 1:
-            # Discussion directly after the initial will always be index 1
-            # If new initial deadline conflicts, shift rounds
-            if round_obj.deadline >= rounds[1].starttime:
-                # Now we need to shift all of the rounds, so loop over them
-                for i in range(1, len(rounds)):
-                    # And grab the duration of the round
-                    duration = self.get_duration(rounds[i].starttime, rounds[i].deadline)
-                    # And grab the deadline of the previous round
-                    new_start = rounds[i - 1].deadline
-                    # Add the 24 hour padding for the first round
-                    if i == 1:
-                        new_start = round_obj.deadline + datetime.timedelta(hours=24)
-                    # end
-                    # And set our new start and end times and save
-                    rounds[i].starttime = new_start
-                    rounds[i].deadline = (new_start + duration)
-                    rounds[i].put()
-                    # end
-                    # end
-                    # end
-
-    # end add_lead_in
-
     def add_rounds(self, num_of_rounds, duration, instructor, buffer_bw_rounds):
         # So first we need to get at the course and section
         course, section = utils.get_course_and_section_objs(self.request, instructor)
@@ -355,78 +498,24 @@ class Rounds(webapp2.RequestHandler):
         # #end
 
         # Copy the summary round if it exists
-        summary = self.copy_summary(section, rounds, num_of_rounds)
+        summary = copy_summary(section, rounds, num_of_rounds)
         # If it exists, pop it off the list
         if summary:
             rounds.pop()
         # end
 
         # Now create all the new rounds
-        new_rounds = self.create_new_rounds(section, rounds, num_of_rounds, duration, buffer_bw_rounds)
+        new_rounds = create_new_rounds(section, rounds, num_of_rounds, duration, buffer_bw_rounds)
 
         # And update the summary round
-        self.update_summary(summary, new_rounds)
+        update_summary(summary, new_rounds)
         # Now update the number of rounds attribute of the section
-        self.update_section_rounds(new_rounds[-1].number, section)
+        update_section_rounds(new_rounds[-1].number, section)
 
-        # Now grab all of the rounds again
-        rounds = model.Round.query(ancestor=section.key).fetch()
-        # And send a success message
+        # Now send a success message
         utils.log('Successfully added {0} new rounds.'.format(num_of_rounds), type='Success!', handler=self)
 
     # end add_rounds
-
-    def create_new_rounds(self, section, rounds, num_of_rounds, duration, buffer_bw_rounds):
-        # Now grab the current last round number
-        current_last_round = rounds[-1].number
-        # We need the end time of the last round currently in this section
-        last_time = rounds[-1].deadline
-        # And grab the start buffer from the previous round
-        start_buffer = rounds[-1].buffer_time
-        # Now we need to compute new start and end times for the new rounds
-        start_times, end_times = self.get_new_times(last_time, num_of_rounds, duration, buffer_bw_rounds, start_buffer)
-        # Let's keep a list of the newly added rounds
-        new_rounds = list()
-        # Now let's just loop over the number of rounds
-        for i in range(num_of_rounds):
-            # And increment the current round for this iteration
-            current_last_round += 1
-            # Create a new rounds object
-            new_round = model.Round(parent=section.key, id=current_last_round)
-            # Set the starttime and deadline
-            new_round.starttime = start_times[i]
-            new_round.deadline = end_times[i]
-            # And the round number
-            new_round.number = current_last_round
-            # And save our object
-            new_round.put()
-            # And add it to our list
-            new_rounds.append(new_round)
-        # end
-        return new_rounds
-
-    # end create_new_rounds
-
-    def get_new_times(self, start, num, duration, delay, start_buffer):
-        # First, we need to get the start time into something we can work with
-        # Grab the current time
-        start += datetime.timedelta(hours=start_buffer)
-
-        # Ok, now we need to create our new start and end times list
-        start_times = list()
-        end_times = list()
-        # And loop the correct number of times
-        for i in range(num):
-            # Create start and end times with the given duration and delay
-            start_time = start + datetime.timedelta(hours=i * (duration + delay))
-            end_time = start + datetime.timedelta(hours=(i + 1) * (duration + delay))
-            # And add to our arrays
-            start_times.append(start_time)
-            end_times.append(end_time)
-        # end
-        return start_times, end_times
-
-    # end get_new_times
 
     def delete_round(self, instructor, round_id):
         # So first we need to get at the course and section
@@ -442,7 +531,7 @@ class Rounds(webapp2.RequestHandler):
         # end
 
         # Now shift all the rounds and remove the round with the input id
-        self.shift_rounds(rounds, round_id)
+        shift_rounds(rounds, round_id)
 
         # Now let's check if we need to copy a summary question over or not
         if rounds[-1].description == 'summary':
@@ -450,10 +539,10 @@ class Rounds(webapp2.RequestHandler):
             rounds[-2].put().delete()
             rounds.pop(-2)
             # And copy the summary round and update the times
-            summary = self.copy_summary(section, rounds, -1)
+            summary = copy_summary(section, rounds, -1)
             # Remove the old summary from the list
             rounds.pop()
-            self.update_summary(summary, rounds)
+            update_summary(summary, rounds)
         else:
             # Finally, remove the very last round from the list
             rounds[-1].put().delete()
@@ -462,38 +551,11 @@ class Rounds(webapp2.RequestHandler):
         # Since we shifted rounds forward, remove the last round from the list
         rounds.pop()
         # And update the section
-        self.update_section_rounds(rounds[-1].number, section)
+        update_section_rounds(rounds[-1].number, section)
         # And send a success message
         utils.log('Successfully deleted round {0}'.format(round_id), type='Success!', handler=self)
 
     # end delete_rounds
-
-    def shift_rounds(self, rounds, round_id):
-        # Now look for the round with the input id
-        for i in range(len(rounds)):
-            # Look for the correct round
-            if rounds[i].number == round_id:
-                # Now loop over the rest of the rounds (except the very last)
-                for j in range(i, len(rounds) - 1):
-                    # We're just dealing with normal discussions
-                    # and we can just shift the values directly
-                    rounds[j].description = rounds[j + 1].description
-                    # No need to move anything quiz related since it isn't
-                    # a initial or summary question
-                    # Lastly, we need to compute the duration to move over
-                    duration = self.get_duration(rounds[j + 1].starttime, rounds[j + 1].deadline)
-                    # Keep the old start time of rounds[j] and calculate
-                    # the new end time
-                    rounds[j].deadline = rounds[j].starttime + duration
-                    # And store it to the database
-                    rounds[j].put()
-                # end
-                # Break out of the outter loop
-                break
-                # end
-                # end
-
-    # end shift_rounds
 
     def edit_round(self, instructor, round_id):
         # So first we need to get at the course and section
@@ -515,7 +577,6 @@ class Rounds(webapp2.RequestHandler):
         # and get the start and end times for the round
         start_time = utils.to_utc(self.request.get('start_time'))
         deadline = utils.to_utc(self.request.get('deadline'))
-
 
         # Loop over the rounds to find the one we're trying to edit
         for i in range(len(rounds)):
@@ -549,7 +610,7 @@ class Rounds(webapp2.RequestHandler):
                         # of the rounds, so loop over them
                         for j in range(i + 1, len(rounds)):
                             # First, get the duration of the round
-                            duration = self.get_duration(rounds[j].starttime, rounds[j].deadline)
+                            duration = get_duration(rounds[j].starttime, rounds[j].deadline)
                             # Now set the new start time to be the
                             # deadline of the previous round
                             rounds[j].starttime = rounds[j - 1].deadline
@@ -591,70 +652,6 @@ class Rounds(webapp2.RequestHandler):
 
     # end start_rounds
 
-    def copy_summary(self, section, rounds, num_of_rounds):
-        summary = None
-        # First, check if there's even a summary round to copy
-        if rounds[-1].description == 'summary':
-            # If so, create a new summary round with those properties
-            # But change it to be the last round after adding num_of_rounds
-            summary_round_num = rounds[-1].number + num_of_rounds
-            summary = model.Round(parent=section.key, id=summary_round_num)
-            # Now copy over all the pertinent summary information
-            summary.starttime = rounds[-1].starttime
-            summary.deadline = rounds[-1].deadline
-            summary.number = summary_round_num
-            summary.is_quiz = True
-            summary.quiz = rounds[-1].quiz
-            summary.description = rounds[-1].description
-            summary.is_anonymous = rounds[-1].is_anonymous
-            # Now remove the summary from the current rounds
-            rounds[-1].put().delete()
-        # end
-        return summary
-
-    # end copy_summary
-
-    def update_summary(self, summary, rounds):
-        # And check if a summary round was saved
-        if summary:
-            # We need to calculate the old duration of the summary round
-            duration = self.get_duration(summary.starttime, summary.deadline)
-            # Now grab the new start time from the last round's deadline
-            new_start = rounds[-1].deadline
-            # Set the summary start time to be the end of the last new round
-            summary.starttime = rounds[-1].deadline
-            summary.deadline = rounds[-1].deadline + duration
-            # And save it to the database and add to our list
-            summary.put()
-            rounds.append(summary)
-            # end
-
-    # end update_summary
-
-    def update_section_rounds(self, num, section):
-        # Update the section rounds attribute if necessary
-        if num != section.rounds:
-            section.rounds = num
-            section.put()
-            # end
-
-    # end update_section_rounds
-
-    def get_duration(self, start, end):
-        duration = 0
-        # First, check what type start and end were sent as
-        if type(start) != datetime.datetime:
-            start = utils.str_to_datetime(start)
-        # end
-        if type(end) != datetime.datetime:
-            end = utils.str_to_datetime(end)
-        # end
-
-        # Simply return the end time minus the start time
-        return (end - start)
-
-    # end get_duration
-
     def end_current_round(self, instructor):
         utils.log("trying to end the current round")
         course, section = utils.get_course_and_section_objs(self.request, instructor)
@@ -664,7 +661,7 @@ class Rounds(webapp2.RequestHandler):
             utils.log("current round is empty!")
             return
         utils.log("current round is number " + str(current_round.number))
-        # if/else is to support both legacy (string) and new (datetime) datatypes
+        # if/else is to support both legacy (string) and new (datetime) data types
         current_round.deadline = datetime.datetime.now()
         current_round.put()
         if next_round:

--- a/src/controller/student/rounds.py
+++ b/src/controller/student/rounds.py
@@ -4,7 +4,7 @@ rounds.py
 Implements the APIs for Student role in the app.
 
 - Author(s): Rohit Kapoor, Swaroop Joshi
-- Last Modified: May 30, 2016
+- Last Modified: Sep 2, 2016
 
 --------------------
 
@@ -19,6 +19,76 @@ from google.appengine.api import users
 from google.appengine.ext import ndb
 
 from src import model, utils
+
+
+def find_prev_round_responses(current_round):
+    prev_round_number = current_round.number - 1
+    section = current_round.key.parent().get()
+    req_round = model.Round.get_by_number(section_key=section.key, number=prev_round_number)
+    utils.log('req_round = Round#' + str(req_round.number))
+    return model.Response.query(ancestor=req_round.key).fetch() if req_round else None
+
+
+def quiz_view_template(student, rround, template_values):
+    # Grab the response for this round by this student
+    response = model.Response.get_by_id(student.email, parent=rround.key)
+    # And if the question has been previously answered
+    if response:
+        # Set template values for what the student previously said
+        template_values['option'] = response.option
+        template_values['comment'] = response.comment
+        template_values['summary'] = response.summary
+    # end
+    # Now set the remaining template values directly
+    template_values['question'] = rround.quiz.question
+    template_values['options'] = rround.quiz.options
+    template_values['number'] = rround.quiz.options_total
+
+
+def group_comments(group, section, previous_round):
+    # Init an empty list for holding the comments
+    comments = []
+    did_not_participate = []
+    # Now loop over the members in the group
+    for student_email in group.members:
+        # Grab each response from the previous round
+        response = model.Response.get_by_id(student_email, parent=previous_round.key)
+
+        # Get the student's info
+        s = section.find_student_info(student_email)
+
+        if response:
+            comment = {
+                'alias': s.alias, 'email': s.email,
+                'response': response.comment, 'opinion': response.response
+            }
+            # Get thumbs if they exist
+            if response.thumbs:
+                _thumbs = []
+                for _email, _value in response.thumbs.iteritems():
+                    s_info = section.find_student_info(_email)
+                    name = s_info.alias if s_info and section.is_anonymous else _email
+                    _thumbs.append((name, _value))  # Add as a tuple
+                comment['thumbs'] = sorted(_thumbs)  # Send as sorted tuples
+
+            # If the response has an associated option
+            if response.option and response.option != 'NA':
+                # Grab the option
+                utils.log('response.option = ' + str(response.option))
+                opt = int(response.option[-1]) - 1
+                comment['option'] = previous_round.quiz.options[opt]
+            else:
+                comment['option'] = ''  # default
+
+            # And finally add the comment to the list
+            comments.append(comment)
+        else:
+            # Else note down who did not participate
+            name = s.alias if section.is_anonymous else s.email
+            did_not_participate.append(name)
+
+    utils.log('Comments = ' + str(comments))
+    return comments, sorted(did_not_participate)
 
 
 class Rounds(webapp2.RequestHandler):
@@ -179,7 +249,7 @@ class Rounds(webapp2.RequestHandler):
             # Now we need to check if it's the initial or summary question
             if requested_round.is_quiz:
                 # And set template values for quiz round
-                self.quiz_view_template(student, requested_round, template_values)
+                quiz_view_template(student, requested_round, template_values)
                 # And set the right template
                 template = utils.jinja_env().get_template('students/round.html')
             else:
@@ -215,28 +285,10 @@ class Rounds(webapp2.RequestHandler):
 
                 # 4. Grab all posts from the previous round (initial)
                 initial = model.Round.get_by_id(1, parent=section.key)
-                initial_answers = self.group_comments(group, section, initial)
+                initial_answers = group_comments(group, section, initial)
                 template_values['initial_answers'] = initial_answers
 
     # end seq_discussion_view_template
-
-
-    def quiz_view_template(self, student, rround, template_values):
-        # Grab the response for this round by this student
-        response = model.Response.get_by_id(student.email, parent=rround.key)
-        # And if the question has been previously answered
-        if response:
-            # Set template values for what the student previously said
-            template_values['option'] = response.option
-            template_values['comment'] = response.comment
-            template_values['summary'] = response.summary
-        # end
-        # Now set the remaining template values directly
-        template_values['question'] = rround.quiz.question
-        template_values['options'] = rround.quiz.options
-        template_values['number'] = rround.quiz.options_total
-
-    # end quiz_view_template
 
     def discussion_view_template(self, student, section, round_number, template_values):
         student_info = utils.get_student_info(student.email, section.students)
@@ -253,9 +305,10 @@ class Rounds(webapp2.RequestHandler):
                     previous_round = model.Round.get_by_id(round_number - 1, parent=section.key)
                 # end
                 # Now grab all the group comments for the previous round
-                comments = self.group_comments(group, section, previous_round)
+                comments, did_not_participate = group_comments(group, section, previous_round)
                 # Set the template value for all the group comments
                 template_values['comments'] = comments
+                template_values['did_not_participate'] = did_not_participate
                 # Grab the requested round
                 requested_round = model.Round.get_by_id(round_number, parent=section.key)
                 # Grab the discussion description
@@ -270,53 +323,6 @@ class Rounds(webapp2.RequestHandler):
                     template_values['response'] = ','.join(str(item) for item in stu_response.response)
 
     # end discussion_view_template
-
-    def group_comments(self, group, section, previous_round):
-        # Init an empty list for holding the comments
-        comments = []
-        # Now loop over the members in the group
-        for _student in group.members:
-            # Grab each response from the previous round
-            response = model.Response.get_by_id(_student, parent=previous_round.key)
-            # Check that that student actually answered the previous
-            # Loop over the students in the section
-            for s in section.students:
-                # And look for the current group member
-                if s.email == _student:
-                    # Grab their alias, email, comment, and response
-                    comment = {'alias': s.alias, 'email': s.email,
-                               'response': response.comment if response else 'Did not participate in the last round',
-                               'opinion': response.response if response else '',
-                               'type': 'Text' if response else ''}
-
-                    # Get thumbs if they exist
-                    if response:
-                        if response.comment:
-                            if response.thumbs:
-                                utils.log('Thumbs for {0} = {1}'.format(response.comment, str(response.thumbs)))
-                                _thumbs = []
-                                for _key, _value in response.thumbs.iteritems():
-                                    name = section.find_alias(_key) if section.is_anonymous else _key
-                                    _thumbs.append((name, _value))
-                                comment['thumbs'] = _thumbs
-                                utils.log('Thumbs data for {0} = {1}'.format(response.comment, json.dumps(comment['thumbs'])))
-
-                    # If the response has an associated option
-                    if response and response.option and response.option != 'NA':
-                        # Grab the option
-                        utils.log('response.option = ' + str(response.option))
-                        opt = int(response.option[-1]) - 1
-                        comment['option'] = previous_round.quiz.options[opt]
-                    else:
-                        comment['option'] = ''  # default
-                    # And finally add the comment to the list
-                    comments.append(comment)
-                    # break
-
-        utils.log('Comments = ' + str(comments))
-        return comments
-
-        # end group_comments
 
     def save_submission(self, student, current_round):
         # Create a new response object
@@ -354,8 +360,26 @@ class Rounds(webapp2.RequestHandler):
             for i in range(1, len(res)):
                 # And save them in our response object for the db
                 response.response.append(res[i])
-                # end
-        # end
+
+            # Get all responses of the previous round
+            prev_responses = find_prev_round_responses(current_round)
+
+            # Fetch thumbs from the view
+            in_thumbs = json.loads(self.request.get('thumbs'))
+
+            if in_thumbs and prev_responses:
+                utils.log('in_thumbs = {0}'.format(str(in_thumbs)))
+
+                # Add the thumbs info. to the previous round's responses
+                for prev_resp in prev_responses:
+                    if in_thumbs.has_key(prev_resp.student):
+                        _thumbs = prev_resp.thumbs.copy()
+                        prev_resp.add_to_thumbs(student.email, in_thumbs[prev_resp.student])
+                    utils.log('For' + prev_resp.comment + ', old thumbs = '
+                              + (str(_thumbs) if _thumbs else 'Empty')
+                              + ', new thumbs = ' + str(prev_resp.thumbs))
+                    prev_resp.put()
+
         # Grab the deadline and the current time
         deadline = current_round.deadline
         current_time = datetime.datetime.now()
@@ -364,25 +388,7 @@ class Rounds(webapp2.RequestHandler):
             # Set the comment and email, and save in the database
             response.comment = comment
             response.student = student.email
-            utils.log('comment = {0}, response = {1}'.format(comment, response.response))
-
-            # Get all responses of the previous round
-            prev_responses = self.find_prev_round_responses(current_round)
-
-            # Fetch thumbs from the view
-            in_thumbs = json.loads(self.request.get('thumbs'))
-
-            if in_thumbs:
-                utils.log('in_thumbs = {0}'.format(str(in_thumbs)))
-                for prev_resp in prev_responses:
-                    if in_thumbs.has_key(prev_resp.student):
-                        _thumbs = prev_resp.thumbs.copy()
-                        prev_resp.add_to_thumbs(student.email, in_thumbs[prev_resp.student])
-                        # _thumbs[prev_resp.student] = in_thumbs[prev_resp.student]
-                    utils.log('For' + prev_resp.comment + ', old thumbs = '
-                              + (str(_thumbs) if _thumbs else 'Empty')
-                              + ', new thumbs = ' + str(prev_resp.thumbs))
-                    prev_resp.put()
+            # utils.log('comment = {0}, response = {1}'.format(comment, response.response))
 
             response.put()
             utils.log('Your response has been saved. You can edit it any time before the deadline. ',
@@ -392,14 +398,5 @@ class Rounds(webapp2.RequestHandler):
             utils.error('Sorry, the time for submission for this round has expired \
            and your response was not saved, please wait for the next round.',
                         handler=self)
-
-    # end save_submission
-
-    def find_prev_round_responses(self, current_round):
-        prev_round_number = current_round.number - 1
-        section = current_round.key.parent().get()
-        req_round = model.Round.get_by_number(section_key=section.key, number=prev_round_number)
-        utils.log('req_round = Round#' + str(req_round.number))
-        return model.Response.query(ancestor=req_round.key).fetch() if req_round else None
 
 # end class Rounds

--- a/src/controller/student/rounds.py
+++ b/src/controller/student/rounds.py
@@ -240,6 +240,15 @@ class Rounds(webapp2.RequestHandler):
             template_values['rounds'] = section.current_round
             template_values['num_total_rounds'] = section.rounds
             template_values['show_name'] = not section.is_anonymous
+
+            # Send round names
+            if section.has_rounds:
+                disc_round_names = ['Round ' + str(i) for i in range(1, section.rounds - 2)] + ['Latest Posts']
+            else:
+                disc_round_names = ['Discussion']
+            round_names = ['Initial Submission'] + disc_round_names + ['Final Submission']
+            template_values['round_names'] = round_names
+
             logout_url = users.create_logout_url(self.request.uri)
             template_values['logouturl'] = logout_url
             from src import config
@@ -285,7 +294,7 @@ class Rounds(webapp2.RequestHandler):
 
                 # 4. Grab all posts from the previous round (initial)
                 initial = model.Round.get_by_id(1, parent=section.key)
-                initial_answers = group_comments(group, section, initial)
+                initial_answers, did_not_participate = group_comments(group, section, initial)
                 template_values['initial_answers'] = initial_answers
 
     # end seq_discussion_view_template

--- a/src/controller/student/rounds.py
+++ b/src/controller/student/rounds.py
@@ -289,6 +289,18 @@ class Rounds(webapp2.RequestHandler):
                                'opinion': response.response if response else '',
                                'type': 'Text' if response else ''}
 
+                    # Get thumbs if they exist
+                    if response:
+                        if response.comment:
+                            if response.thumbs:
+                                utils.log('Thumbs for {0} = {1}'.format(response.comment, str(response.thumbs)))
+                                _thumbs = []
+                                for _key, _value in response.thumbs.iteritems():
+                                    name = section.find_alias(_key) if section.is_anonymous else _key
+                                    _thumbs.append((name, _value))
+                                comment['thumbs'] = _thumbs
+                                utils.log('Thumbs data for {0} = {1}'.format(response.comment, json.dumps(comment['thumbs'])))
+
                     # If the response has an associated option
                     if response and response.option and response.option != 'NA':
                         # Grab the option
@@ -361,12 +373,15 @@ class Rounds(webapp2.RequestHandler):
             in_thumbs = json.loads(self.request.get('thumbs'))
 
             if in_thumbs:
+                utils.log('in_thumbs = {0}'.format(str(in_thumbs)))
                 for prev_resp in prev_responses:
                     if in_thumbs.has_key(prev_resp.student):
-                        prev_resp.add_to_thumbs(prev_resp.student, in_thumbs[prev_resp.student])
-                    utils.log('In prev_resp by ' + prev_resp.student
-                              + '(' + prev_resp.comment + '), putting thumbs = '
-                              + str(prev_resp.thumbs))
+                        _thumbs = prev_resp.thumbs.copy()
+                        prev_resp.add_to_thumbs(student.email, in_thumbs[prev_resp.student])
+                        # _thumbs[prev_resp.student] = in_thumbs[prev_resp.student]
+                    utils.log('For' + prev_resp.comment + ', old thumbs = '
+                              + (str(_thumbs) if _thumbs else 'Empty')
+                              + ', new thumbs = ' + str(prev_resp.thumbs))
                     prev_resp.put()
 
             response.put()

--- a/src/controller/student/rounds.py
+++ b/src/controller/student/rounds.py
@@ -296,6 +296,7 @@ class Rounds(webapp2.RequestHandler):
                 initial = model.Round.get_by_id(1, parent=section.key)
                 initial_answers, did_not_participate = group_comments(group, section, initial)
                 template_values['initial_answers'] = initial_answers
+                template_values['did_not_participate'] = did_not_participate
 
     # end seq_discussion_view_template
 

--- a/src/model/Response.py
+++ b/src/model/Response.py
@@ -17,5 +17,15 @@ class Response(ndb.Model):
     """ List of Strings. Can take values ``support``, ``disagree`` or ``neutral``."""
     summary = ndb.StringProperty(indexed=False)
     """ String. The summary post in the last round."""
-    student = ndb.StringProperty(required=True)
+    student = ndb.StringProperty(required=True, indexed=True)
     """ String. Email of the `Student`_ who is the author of this response."""
+    thumbs = ndb.JsonProperty(default={})
+
+    def add_to_thumbs(self, in_key, in_value):
+        if not self.thumbs:
+            self.thumbs = {}
+        self.thumbs[in_key] = in_value
+
+    def get_response_by_student(round_key, student_email):
+        req_response = Response.query(ancestor=round_key).filter(Response.student == student_email).fetch(1)
+        return req_response if req_response else None

--- a/src/model/Response.py
+++ b/src/model/Response.py
@@ -20,6 +20,7 @@ class Response(ndb.Model):
     student = ndb.StringProperty(required=True, indexed=True)
     """ String. Email of the `Student`_ who is the author of this response."""
     thumbs = ndb.JsonProperty(default={})
+    """ JSON. Indicates how others responded to this post in the followup round. """
 
     def add_to_thumbs(self, in_key, in_value):
         if not self.thumbs:

--- a/src/model/Round.py
+++ b/src/model/Round.py
@@ -40,3 +40,8 @@ class Round(ndb.Model):  # FIXME move under a Group?
     """ DateTime representation of the round start time. """
     buffer_time = ndb.IntegerProperty(default=0, indexed=False)
     """ Integer. Represents the buffer time between rounds."""
+
+    @staticmethod
+    def get_by_number(section_key, number):
+        req_round = Round.query(ancestor=section_key).filter(Round.number == number).fetch(1)[0]
+        return req_round if req_round else None

--- a/src/model/Round.py
+++ b/src/model/Round.py
@@ -41,7 +41,20 @@ class Round(ndb.Model):  # FIXME move under a Group?
     buffer_time = ndb.IntegerProperty(default=0, indexed=False)
     """ Integer. Represents the buffer time between rounds."""
 
+    type = ndb.IntegerProperty(default=0, indexed=True)
+    """ Type of the round. 1=initial question, 2=discussoin round, 3=sequential discussion round, 4=read only round, 5=final question"""
+
     @staticmethod
     def get_by_number(section_key, number):
         req_round = Round.query(ancestor=section_key).filter(Round.number == number).fetch(1)[0]
         return req_round if req_round else None
+
+    @staticmethod
+    def get_round_type(value):
+        types = {'default': 0, 'initial': 1, 'discussion': 2, 'sequential': 3, 'readonly': 4, 'final': 5}
+        return types[value] if types.has_key(value) else 0
+
+    @staticmethod
+    def fetch_real_rounds(section_key):
+        rounds = [r for r in Round.query(ancestor=section_key).filter(Round.type != 4).fetch()]
+        return rounds

--- a/src/model/Section.py
+++ b/src/model/Section.py
@@ -40,3 +40,10 @@ class Section(ndb.Model):
     has_rounds = ndb.BooleanProperty(default=True, indexed=False)
     """ Boolean. If ``True``, asynchronous, rounds-based discussion, else sequential """
     export_info = ndb.StringProperty(required=False)
+
+    def find_alias(self, email):
+        if self.students:
+            for student_info in self.students:
+                if student_info.email == email:
+                    return student_info.alias
+        return None

--- a/src/model/Section.py
+++ b/src/model/Section.py
@@ -41,9 +41,8 @@ class Section(ndb.Model):
     """ Boolean. If ``True``, asynchronous, rounds-based discussion, else sequential """
     export_info = ndb.StringProperty(required=False)
 
-    def find_alias(self, email):
+    def find_student_info(self, email):
         if self.students:
-            for student_info in self.students:
-                if student_info.email == email:
-                    return student_info.alias
-        return None
+            return next(s for s in self.students if s.email == email)
+        else:
+            return None

--- a/src/static/css/custom-style.css
+++ b/src/static/css/custom-style.css
@@ -220,6 +220,7 @@ a:hover {
 .support {
     background-color: rgb(203, 255, 186);
 }
+
 .neutral {
     background-color: rgb(186, 237, 255);
 }
@@ -329,4 +330,11 @@ a:hover {
 .thumbnail {
     padding-left: 15px;
     padding-right: 15px;
+}
+
+/* Badge styling for thumbs up */
+.badge {
+    font-weight: 100;
+    background-color: #110F80;
+    margin-bottom: 10px;
 }

--- a/src/templates/layouts/student_base.html
+++ b/src/templates/layouts/student_base.html
@@ -10,8 +10,7 @@
 {{ super() }}
 {% for i in range(0,rounds) %}
 <li class="{% if curr_page == i+1 %}nav-active round-viewing{% else %}nav-hover{% endif %}">
-<a href="/student_rounds?section={{sectionKey}}&round={{i+1}}" data-round="{{i+1}}" class="nav_reload">{% if i==0 %}Initial Submission {% elif
-    i==num_total_rounds-1 %}Final Submission {% elif i==num_total_rounds-2 %}Latest Posts{% else %}Round {{i}}{% endif %}</a>
+<a href="/student_rounds?section={{sectionKey}}&round={{i+1}}" data-round="{{i+1}}" class="nav_reload">{{ round_names[i] }}</a>
 </li>
 {% endfor %}
 {% endblock topnavbar %}

--- a/src/templates/students/discussion.html
+++ b/src/templates/students/discussion.html
@@ -35,21 +35,20 @@
                     <h2>{% if show_name -%} {{comment.email}} {%- else -%}{{comment.alias}}{%- endif -%} {%- if alias == comment.alias -%}&nbsp;(You) {%- endif -%}</h2>
                 </div>
 
-                {%- if not expired -%}
-                <div class="col-md-6">
+                {%- if not expired and comment.type!='' -%}
+                <div class="col-md-12">
+                <button type="button" data-toggle="tooltip" title="Neutral" id="neu_{{loop.index}}" onclick="updateAlert(this)" class="pull-right btn btn-sm btn-info" {% if
+                            expired -%} disabled="true" {%- endif -%}>
+                            <span class="glyphicon glyphicon-question-sign" aria-hidden="true"></span> Did not understand some key points
+                    </button>
                     <button type="button" data-toggle="tooltip" title="Disagree" id="dis_{{loop.index}}" onclick="updateAlert(this)" class="pull-right btn btn-sm btn-danger" {% if
                             expired -%} disabled="true" {%- endif -%}>
-                            <span class="glyphicon glyphicon-thumbs-down" aria-hidden="true"></span> Disagree
-                    </button> 
-
-                    <button type="button" data-toggle="tooltip" title="Neutral" id="neu_{{loop.index}}" onclick="updateAlert(this)" class="pull-right btn btn-sm btn-info" {% if
-                            expired -%} disabled="true" {%- endif -%}>
-                            <span class="glyphicon glyphicon-hand-right" aria-hidden="true"></span> Neutral
-                    </button> 
+                            <span class="glyphicon glyphicon-thumbs-down" aria-hidden="true"></span> Disagree with at least one key point
+                    </button>
 
                     <button type="button" data-toggle="tooltip" title="Support" id="sup_{{loop.index}}" onclick="updateAlert(this)" class="pull-right btn btn-sm btn-success" {% if
                             expired -%} disabled="true" {%- endif -%}>
-                        <span class="glyphicon glyphicon-thumbs-up" aria-hidden="true"></span> Support
+                        <span class="glyphicon glyphicon-thumbs-up" aria-hidden="true"></span> Agree with ALL key points
                     </button>
                 </div>
                 {%- endif -%}
@@ -57,34 +56,24 @@
             {% if comment.option %}
             <span class="alert alert-info" style="padding: 3px;display: inline-block;margin-bottom: 5px;">Option selected: {{comment.option}}</span>
             {% endif %}
-            {% for opinion in comment.opinion %}
+
+            <div class="row">
+                <div class="well col-md-12"
+                     style="font-family:'Helvetica Neue',Helvetica,Arial,sans-serif; font-size: 1.2em;font-weight: 300; margin-bottom: 10px; margin-top: 10px;">
+                    {% for opinion in comment.opinion %}
             <span class="badge"
                   style="font-weight: 100; background-color: #110F80; margin-bottom: 10px">S{{loop.index}}:
                 <span
-                    class="glyphicon glyphicon-{%- if opinion == 'support' -%}thumbs-up{%- elif opinion == 'neutral' -%}hand-right{%- else -%}thumbs-down{%- endif -%}"
+                    class="glyphicon glyphicon-{%- if opinion == 'support' -%}thumbs-up{%- elif opinion == 'neutral' -%}question-sign{%- else -%}thumbs-down{%- endif -%}"
                     aria-hidden="true"></span>
             </span>
             {% endfor %}
-            <div class="row">
-                <div class="well col-md-12"
-                     style="font-family:'Helvetica Neue',Helvetica,Arial,sans-serif; font-size: 1.2em;font-weight: 300; margin-bottom: 10px">
                     {{comment.response|safe}}
                 </div>
             </div>
         </div>
     {% endfor %}
-    {% if not expired -%}
-    <div id="alert_comment" class="alert alert-info fade in" role="alert" style="display: none;">
-        <button type="button" class="close" aria-label="Close">
-            <span aria-hidden="true">&times;</span>
-        </button>
-        <h4>Be sure to explain, in the box below...</h4>
-        {% for comment in comments %}
-        <p id="alert_{{loop.index}}"></p>
-        {% endfor %}
-    </div>
-    {% endif %}
-</div> 
+</div>
 </div>
 </div>
 
@@ -182,26 +171,21 @@
         return true;
     }
 
+
     function updateAlert(obj) {
         var type = obj.id.substring(0, 3);
         var index = obj.id.substring(4);
         if (type == "sup") {
             $("#jum_" + index).removeClass().addClass('jumbotron').addClass('support');
-            $("#alert_" + index).html("Why you Support S" + index + "?");
             resp[index] = 'support';
-            $("#alert_comment").show();
         }
         else if (type == "neu") {
             $("#jum_" + index).removeClass().addClass('jumbotron').addClass('neutral');
-            $("#alert_" + index).html("Why you are neutral with S" + index + "...");
             resp[index] = 'neutral';
-            $("#alert_comment").show();
         }
         else {
             $("#jum_" + index).removeClass().addClass('jumbotron').addClass('disagree');
-            $("#alert_" + index).html("Why you Disagree with S" + index + "?");
             resp[index] = 'disagree';
-            $("#alert_comment").show();
         }
     }
 

--- a/src/templates/students/discussion.html
+++ b/src/templates/students/discussion.html
@@ -35,7 +35,7 @@
                     <h2>{% if show_name -%} {{comment.email}} {%- else -%}{{comment.alias}}{%- endif -%} {%- if alias == comment.alias -%}&nbsp;(You) {%- endif -%}</h2>
                 </div>
 
-                {%- if not expired and comment.type!='' -%}
+                {%- if not expired and comment.response -%}
                 <div class="col-md-12">
                 <button type="button" data-toggle="tooltip" title="Neutral" id="neu_{{loop.index}}" onclick="updateAlert(this,'{{comment.email}}',0)" class="pull-right btn btn-sm btn-info" {% if
                             expired -%} disabled="true" {%- endif -%}>
@@ -54,24 +54,32 @@
                 {%- endif -%}
             </div>
             {% if comment.option %}
-            <span class="alert alert-info" style="padding: 3px;display: inline-block;margin-bottom: 5px;">Option selected: {{comment.option}}</span>
+            <span class="alert alert-info" style="padding: 3px;display: inline-block;margin-bottom: 5px;">Option selected: {{comment.option}}</span><br>
             {% endif %}
 
             {% for (key, value) in comment.thumbs %}
+                {%  if expired %}
                 <span class="badge">{{ key }}: <span
                         class="glyphicon glyphicon-{%- if value == 1 -%}thumbs-up{%- elif value == 0 -%}question-sign{%- else -%}thumbs-down{%- endif -%}"
                         aria-hidden="true"></span></span>
+                {% endif %}
             {% endfor %}
             <div class="row">
                 <div class="well col-md-12"
                      style="font-family:'Helvetica Neue',Helvetica,Arial,sans-serif; font-size: 1.2em;font-weight: 300; margin-bottom: 10px; margin-top: 10px;">
-
-
                     {{ comment.response|safe }}
                 </div>
             </div>
         </div>
     {% endfor %}
+    {% if did_not_participate %}
+    <div class="jumbotron">
+        <strong>These students did not participate in the last round</strong>
+        {% for name in did_not_participate %}
+            <p>{{ name }}</p>
+        {% endfor %}
+    </div>
+    {% endif %}
 </div>
 </div>
 </div>
@@ -165,10 +173,9 @@
     // returns true if they have, false if there are any comments they have
     // not picked an opinion on.
     function selAll() {
-        //for (var i = 1; i <= l; i++) {
-        //    if (!resp[i]) return false;
-        //}
-        // TODO: Enable this again
+        for (var i = 1; i <= l; i++) {
+            if (!resp[i]) return false;
+        }
         return true;
     }
 

--- a/src/templates/students/discussion.html
+++ b/src/templates/students/discussion.html
@@ -37,16 +37,16 @@
 
                 {%- if not expired and comment.type!='' -%}
                 <div class="col-md-12">
-                <button type="button" data-toggle="tooltip" title="Neutral" id="neu_{{loop.index}}" onclick="updateAlert(this)" class="pull-right btn btn-sm btn-info" {% if
+                <button type="button" data-toggle="tooltip" title="Neutral" id="neu_{{loop.index}}" onclick="updateAlert(this,'{{comment.email}}',0)" class="pull-right btn btn-sm btn-info" {% if
                             expired -%} disabled="true" {%- endif -%}>
                             <span class="glyphicon glyphicon-question-sign" aria-hidden="true"></span> Did not understand some key points
                     </button>
-                    <button type="button" data-toggle="tooltip" title="Disagree" id="dis_{{loop.index}}" onclick="updateAlert(this)" class="pull-right btn btn-sm btn-danger" {% if
+                    <button type="button" data-toggle="tooltip" title="Disagree" id="dis_{{loop.index}}" onclick="updateAlert(this,'{{comment.email}}',-1)" class="pull-right btn btn-sm btn-danger" {% if
                             expired -%} disabled="true" {%- endif -%}>
                             <span class="glyphicon glyphicon-thumbs-down" aria-hidden="true"></span> Disagree with at least one key point
                     </button>
 
-                    <button type="button" data-toggle="tooltip" title="Support" id="sup_{{loop.index}}" onclick="updateAlert(this)" class="pull-right btn btn-sm btn-success" {% if
+                    <button type="button" data-toggle="tooltip" title="Support" id="sup_{{loop.index}}" onclick="updateAlert(this,'{{comment.email}}',1)" class="pull-right btn btn-sm btn-success" {% if
                             expired -%} disabled="true" {%- endif -%}>
                         <span class="glyphicon glyphicon-thumbs-up" aria-hidden="true"></span> Agree with ALL key points
                     </button>
@@ -120,6 +120,7 @@
 <script>
     var l = {{comments | length}}
     var resp = [];
+    var thumbs={};
     resp[0] = null;
 
     {% if response %}
@@ -148,12 +149,12 @@
             loadRound(curr_round);
             bootbox.alert('Please choose your opinion for all the comments.');
 
-        }
-        else {
+        } else {
             var $form = $(this);
             var comment = $form.find("textarea").val();
             var url = $form.attr("action");
-            $.post(url, {comm: comment, response: JSON.stringify(resp), section: '{{sectionKey}}'}, function (data) {
+            console.log('Thumbs = '+JSON.stringify(thumbs));
+            $.post(url, {comm: comment, response: JSON.stringify(resp), section: '{{sectionKey}}', thumbs:JSON.stringify(thumbs)}, function (data) {
                 bootbox.alert(data, function () {
                     ocomment = comment;
                 });
@@ -165,29 +166,35 @@
     // returns true if they have, false if there are any comments they have
     // not picked an opinion on.
     function selAll() {
-        for (var i = 1; i <= l; i++) {
-            if (!resp[i]) return false;
-        }
+        //for (var i = 1; i <= l; i++) {
+        //    if (!resp[i]) return false;
+        //}
+        // TODO: Enable this again
         return true;
     }
 
 
-    function updateAlert(obj) {
-        var type = obj.id.substring(0, 3);
-        var index = obj.id.substring(4);
-        if (type == "sup") {
-            $("#jum_" + index).removeClass().addClass('jumbotron').addClass('support');
-            resp[index] = 'support';
+        function updateAlert(obj, email, type) {
+            var index = obj.id.substring(4);
+            var message = 'Current student ';
+
+            if (type == 1) {
+                $("#jum_" + index).removeClass().addClass('jumbotron').addClass('support');
+                resp[index] = 'support';
+                message += 'supports ';
+            } else if (type == 0) {
+                $("#jum_" + index).removeClass().addClass('jumbotron').addClass('neutral');
+                resp[index] = 'neutral';
+                message += 'seeks clarification from ';
+            } else {
+                $("#jum_" + index).removeClass().addClass('jumbotron').addClass('disagree');
+                resp[index] = 'disagree';
+                message += 'disagrees with ';
+            }
+            message += email + '\'s Round ' +{{ curr_page-2 }};
+            console.log(message);
+            thumbs[email] = type;
         }
-        else if (type == "neu") {
-            $("#jum_" + index).removeClass().addClass('jumbotron').addClass('neutral');
-            resp[index] = 'neutral';
-        }
-        else {
-            $("#jum_" + index).removeClass().addClass('jumbotron').addClass('disagree');
-            resp[index] = 'disagree';
-        }
-    }
 
     var ocomment = $('#comment').val();
 

--- a/src/templates/students/discussion.html
+++ b/src/templates/students/discussion.html
@@ -57,18 +57,17 @@
             <span class="alert alert-info" style="padding: 3px;display: inline-block;margin-bottom: 5px;">Option selected: {{comment.option}}</span>
             {% endif %}
 
+            {% for (key, value) in comment.thumbs %}
+                <span class="badge">{{ key }}: <span
+                        class="glyphicon glyphicon-{%- if value == 1 -%}thumbs-up{%- elif value == 0 -%}question-sign{%- else -%}thumbs-down{%- endif -%}"
+                        aria-hidden="true"></span></span>
+            {% endfor %}
             <div class="row">
                 <div class="well col-md-12"
                      style="font-family:'Helvetica Neue',Helvetica,Arial,sans-serif; font-size: 1.2em;font-weight: 300; margin-bottom: 10px; margin-top: 10px;">
-                    {% for opinion in comment.opinion %}
-            <span class="badge"
-                  style="font-weight: 100; background-color: #110F80; margin-bottom: 10px">S{{loop.index}}:
-                <span
-                    class="glyphicon glyphicon-{%- if opinion == 'support' -%}thumbs-up{%- elif opinion == 'neutral' -%}question-sign{%- else -%}thumbs-down{%- endif -%}"
-                    aria-hidden="true"></span>
-            </span>
-            {% endfor %}
-                    {{comment.response|safe}}
+
+
+                    {{ comment.response|safe }}
                 </div>
             </div>
         </div>
@@ -118,9 +117,9 @@
 
 
 <script>
-    var l = {{comments | length}}
+    var l = {{comments | length}};
     var resp = [];
-    var thumbs={};
+    var thumbs = {};
     resp[0] = null;
 
     {% if response %}
@@ -141,7 +140,7 @@
         for ( instance in CKEDITOR.instances ) {
             CKEDITOR.instances[instance].updateElement();
         }
-                
+
         //collect form elements
         if (!selAll()) {
             // Missing some opinions; force reload current page dynamically
@@ -174,27 +173,27 @@
     }
 
 
-        function updateAlert(obj, email, type) {
-            var index = obj.id.substring(4);
-            var message = 'Current student ';
+    function updateAlert(obj, email, type) {
+        var index = obj.id.substring(4);
+        var message = 'Current student ';
 
-            if (type == 1) {
-                $("#jum_" + index).removeClass().addClass('jumbotron').addClass('support');
-                resp[index] = 'support';
-                message += 'supports ';
-            } else if (type == 0) {
-                $("#jum_" + index).removeClass().addClass('jumbotron').addClass('neutral');
-                resp[index] = 'neutral';
-                message += 'seeks clarification from ';
-            } else {
-                $("#jum_" + index).removeClass().addClass('jumbotron').addClass('disagree');
-                resp[index] = 'disagree';
-                message += 'disagrees with ';
-            }
-            message += email + '\'s Round ' +{{ curr_page-2 }};
-            console.log(message);
-            thumbs[email] = type;
+        if (type == 1) {
+            $("#jum_" + index).removeClass().addClass('jumbotron').addClass('support');
+            resp[index] = 'support';
+            message += 'supports ';
+        } else if (type == 0) {
+            $("#jum_" + index).removeClass().addClass('jumbotron').addClass('neutral');
+            resp[index] = 'neutral';
+            message += 'seeks clarification from ';
+        } else {
+            $("#jum_" + index).removeClass().addClass('jumbotron').addClass('disagree');
+            resp[index] = 'disagree';
+            message += 'disagrees with ';
         }
+        message += email + '\'s Round ' +{{ curr_page-2 }};
+        console.log(message);
+        thumbs[email] = type;
+    }
 
     var ocomment = $('#comment').val();
 
@@ -204,5 +203,7 @@
         }
     });
     {% endif %}
+
 </script>
+
 {% endblock script %}

--- a/src/templates/students/discussion.html
+++ b/src/templates/students/discussion.html
@@ -17,10 +17,7 @@
 <div class="container discussion-container" id='pageContent'>
     <div class="card">
     <div class="card-title">
-        <h2>{% if curr_page==0 %}Initial Submission
-            {% elif curr_page==num_total_rounds %}Final Submission
-            {% elif curr_page==num_total_rounds-1 %}Latest Posts
-            {% else %}Round {{curr_page - 1}}{% endif %}
+        <h2>{{ round_names[curr_page-1] }}
             &gt; Welcome {{alias}}
         </h2>
     </div>

--- a/src/templates/students/last_round.html
+++ b/src/templates/students/last_round.html
@@ -29,7 +29,7 @@
                 {% endfor %}
             </div>
 
-            <h3>Final Response</h3>
+            <h3>Final Answer</h3>
             <textarea class="form-control" rows="3" id="comment" placeholder="
             {%- if last_round -%}
             Please enter your final answer.
@@ -39,7 +39,7 @@
             {%- if comment -%}{{comment}}{%- endif -%}
             </textarea>
 
-            <h3>Activity Summary</h3>
+            <h3>Discussion Summary</h3>
             <textarea class="form-control" rows="10" id="summary" name="summary" placeholder="Please enter your summary for this activity ..." required {% if expired -%} disabled="true" {%- endif %}>
             {%- if summary -%}{{summary}}{%- endif -%}
             </textarea>

--- a/src/templates/students/seq_discussion.html
+++ b/src/templates/students/seq_discussion.html
@@ -12,15 +12,15 @@
 <div class="container discussion-container">
     <div class="card">
         <div class="card-title">
-            <h1 class="lead">Welcome {{alias}}</h1>
+            <h2>Welcome {{alias}}</h2>
         </div>
         <div class="card-body">
             {% if description %}
-            <h1 class="well lead" style="font-size: 1.5em !important; white-space: pre-wrap; text-align: left">{{description}}</h1>
+            <h2 class="well lead" style="font-size: 1.5em !important; white-space: pre-wrap; text-align: left">{{description}}</h2>
             {% endif %}
             <div class="card">
                 <div class="card-title">
-                    <h4>Initial Answers</h4>
+                    <h3>Initial Answers</h3>
                 </div>
                 <div class="card-body">
                     <div class="table-responsive">
@@ -40,7 +40,7 @@
             {%- for post in posts -%}
             <div class="card">
                 <div class="card-title">
-                    <h4 style="text-align: left">#{{post.index}} &mdash; {{post.author if show_name else post.author_alias}}</h4>
+                    <h3 style="text-align: left">#{{post.index}} &mdash; {{post.author if show_name else post.author_alias}}</h3>
                 </div>
                 <div class="card-body" style="text-align: left">
                     {{post.text|safe}}

--- a/src/templates/students/seq_discussion.html
+++ b/src/templates/students/seq_discussion.html
@@ -32,6 +32,12 @@
                                 <td style="text-align: left">{{answer.response|safe}}</td>
                             </tr>
                             {% endfor %}
+                            {% for email_or_alias in did_not_participate %}
+                                <tr>
+                                <th style="text-align: left">{{ email_or_alias }}</th>
+                                <td style="text-align: left">(Did not participate)</td>
+                                </tr>
+                            {% endfor %}
                             </tbody>
                         </table>
                     </div>

--- a/src/utils.py
+++ b/src/utils.py
@@ -306,11 +306,6 @@ def get_template_all_courses_and_sections(instructor, course_name, selected_sect
 
 # end get_template_all_courses_and_sections
 
-
-
-# end get_template_all_courses_and_sections
-
-
 def get_course_and_section_objs(page_handler, instructor):
     """
     Given the page handler and the currently logged in instructor, returns the
@@ -418,8 +413,6 @@ def convert_time(old_time):
 
 # end convert_time
 
-
-# end
 
 def send_mail(senders_email, section, subject, message):
     """


### PR DESCRIPTION
* A 'read only' round is added automatically when 'Start Rounds' is clicked in the instructor interface. Students can read the comments they submitted at the end of the last discussion rounds in the tab corresponding that round.
* Many static methods changed to functions
* Displaying round names is simplified by creating an array of names in the controller (.py) code and passing it to the view (jinja templates), instead of inferring names from the round index in the templates.
* Displays if a student did not make a post in a round
